### PR TITLE
Allowing ovpn client file template to be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Role Variables
 | openvpn_proto | string  | udp, tcp | udp | The protocol you want OpenVPN to use |
 | openvpn_dualstack | boolean | | true | Whether or not to use a dualstack (IPv4 + v6) socket |
 | openvpn_config_file                | string  |              | openvpn_{{ openvpn\_proto }}_{{ openvpn_port }} |  The config file name you want to   use                                                                                                                          |
+| openvpn_client_template            | string  |              | client.ovpn.j2 |  Location of template for clients ovpn file                                                                                                                          |
 | openvpn_rsa_bits                   | int     |              | 2048                                           | Number of bit used to protect generated certificates                                                                                                              |
 | openvpn_service_name               | string  |              | openvpn                                        | Name of the service. Used by systemctl to start the service                                                                                                       |
 | openvpn_uninstall                  | boolean | true , false | false                                          | Set to true to uninstall the OpenVPN service                                                                                                                      |

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -46,7 +46,7 @@
 
 - name: generate client config
   template:
-    src: client.ovpn.j2
+    src: {{openvpn_client_template}}
     dest: "/etc/openvpn/{{item.0.item}}-{{inventory_hostname}}.ovpn"
     owner: root
     group: root

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 # vars file for openvpn
 openvpn_config_file: "openvpn_{{ openvpn_proto }}_{{ openvpn_port }}"
+openvpn_client_template: "client.conf.j2"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # vars file for openvpn
 openvpn_config_file: "openvpn_{{ openvpn_proto }}_{{ openvpn_port }}"
-openvpn_client_template: "client.conf.j2"
+openvpn_client_template: "client.ovpn.j2"


### PR DESCRIPTION
Adds `openvpn_client_template` variable to be able to override the template that is used for user customisation.